### PR TITLE
fix typo in requirements.txt for python-gnupg package

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,4 +12,4 @@ pytest
 python_dateutil
 Werkzeug
 recurrent
-gnupg
+python-gnupg


### PR DESCRIPTION
Hey I really like your project. Thank you for your great work!
Recently I followed a mailing list and found that I can't view mails with signatures.
The log says `AttributeError: 'GPG' object has no attribute 'search_keys'` and I found gnupg on PyPI was not updated since 2017.
Maybe this package should be python-gnupg on PyPI I guess?